### PR TITLE
Change ssh pubkey to private in scp command.

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -41,7 +41,7 @@ resource "hcloud_server" "first_control_plane" {
   }
 
   provisioner "local-exec" {
-    command = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${var.public_key} root@${self.ipv4_address}:/etc/rancher/k3s/k3s.yaml ./kubeconfig.yaml"
+    command = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${var.private_key} root@${self.ipv4_address}:/etc/rancher/k3s/k3s.yaml ./kubeconfig.yaml"
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
SCP needs the `private_key` to connect to the provisioned VPS, not the public key as written.