### PR TITLE
feat: add structured kubeconfig output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See a more detailed example with walk-through in the [example folder](./example)
 | <a name="input_name"></a> [name](#input\_name) | Cluster name (used in various places, don't use special chars) | `any` | n/a | yes |
 | <a name="input_network_cidr"></a> [network\_cidr](#input\_network\_cidr) | Network in which the cluster will be placed | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_server_additional_packages"></a> [server\_additional\_packages](#input\_server\_additional\_packages) | Additional packages which will be installed on node creation | `list(string)` | `[]` | no |
-| <a name="input_server_locations"></a> [server\_locations](#input\_server\_locations) | Server locations in which servers will be distributed | `list` | <pre>[<br>  "nbg1",<br>  "fsn1",<br>  "hel1"<br>]</pre> | no |
+| <a name="input_server_locations"></a> [server\_locations](#input\_server\_locations) | Server locations in which servers will be distributed | `list(string)` | <pre>[<br>  "nbg1",<br>  "fsn1",<br>  "hel1"<br>]</pre> | no |
 | <a name="input_ssh_private_key_location"></a> [ssh\_private\_key\_location](#input\_ssh\_private\_key\_location) | Use this private SSH key instead of generating a new one (Attention: Encrypted keys are not supported) | `string` | `null` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | Subnet in which all nodes are placed | `string` | `"10.0.1.0/24"` | no |
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See a more detailed example with walk-through in the [example folder](./example)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agent_groups"></a> [agent\_groups](#input\_agent\_groups) | Configuration of agent groups | <pre>map(object({<br>    type      = string<br>    count     = number<br>    ip_offset = number<br>  }))</pre> | <pre>{<br>  "agent": {<br>    "count": 2,<br>    "ip_offset": 33,<br>    "type": "cx21"<br>  }<br>}</pre> | no |
+| <a name="input_agent_groups"></a> [agent\_groups](#input\_agent\_groups) | Configuration of agent groups | <pre>map(object({<br>    type      = string<br>    count     = number<br>    ip_offset = number<br>  }))</pre> | <pre>{<br>  "default": {<br>    "count": 2,<br>    "ip_offset": 33,<br>    "type": "cx21"<br>  }<br>}</pre> | no |
 | <a name="input_control_plane_server_count"></a> [control\_plane\_server\_count](#input\_control\_plane\_server\_count) | Number of control plane nodes | `number` | `3` | no |
 | <a name="input_control_plane_server_type"></a> [control\_plane\_server\_type](#input\_control\_plane\_server\_type) | Server type of control plane servers | `string` | `"cx11"` | no |
 | <a name="input_create_kubeconfig"></a> [create\_kubeconfig](#input\_create\_kubeconfig) | Create a local kubeconfig file to connect to the cluster | `bool` | `true` | no |
@@ -58,7 +58,8 @@ See a more detailed example with walk-through in the [example folder](./example)
 | <a name="output_agents_public_ips"></a> [agents\_public\_ips](#output\_agents\_public\_ips) | The public IP addresses of the agent servers |
 | <a name="output_control_planes_public_ips"></a> [control\_planes\_public\_ips](#output\_control\_planes\_public\_ips) | The public IP addresses of the control plane servers |
 | <a name="output_k3s_token"></a> [k3s\_token](#output\_k3s\_token) | Secret k3s authentication token |
-| <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Kubeconfig with external IP address |
+| <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Structured kubeconfig data to supply to other providers |
+| <a name="output_kubeconfig_file"></a> [kubeconfig\_file](#output\_kubeconfig\_file) | Kubeconfig file content with external IP address |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | n/a |
 | <a name="output_ssh_private_key"></a> [ssh\_private\_key](#output\_ssh\_private\_key) | Key to SSH into nodes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/agents.tf
+++ b/agents.tf
@@ -25,5 +25,7 @@ module "agent_group" {
   server_count = each.value.count
   server_type  = each.value.type
 
+  additional_packages = var.server_additional_packages
+
   depends_on = [hcloud_server.first_control_plane]
 }

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -19,8 +19,23 @@ resource "local_file" "kubeconfig" {
   file_permission   = "400"
 }
 
-output "kubeconfig" {
+locals {
+  kubeconfig_parsed = yamldecode(local.kubeconfig_external)
+  kubeconfig_data = {
+    host                   = local.kubeconfig_parsed["clusters"][0]["cluster"]["server"]
+    client_certificate     = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-certificate-data"])
+    client_key             = base64decode(local.kubeconfig_parsed["users"][0]["user"]["client-key-data"])
+    cluster_ca_certificate = base64decode(local.kubeconfig_parsed["clusters"][0]["cluster"]["certificate-authority-data"])
+  }
+}
+
+output "kubeconfig_file" {
   value       = local.kubeconfig_external
-  description = "Kubeconfig with external IP address"
+  description = "Kubeconfig file content with external IP address"
   sensitive   = true
+}
+
+output "kubeconfig" {
+  description = "Structured kubeconfig data to supply to other providers"
+  value       = local.kubeconfig_data
 }

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -38,4 +38,5 @@ output "kubeconfig_file" {
 output "kubeconfig" {
   description = "Structured kubeconfig data to supply to other providers"
   value       = local.kubeconfig_data
+  sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,7 @@ variable "control_plane_server_type" {
 variable "server_locations" {
   description = "Server locations in which servers will be distributed"
   default     = ["nbg1", "fsn1", "hel1"]
+  type        = list(string)
 }
 
 variable "agent_groups" {


### PR DESCRIPTION
This changes the kubeconfig output to structured data which can be used as provider configuration.

Example: 

```terraform

data "terraform_remote_state" "cluster_base" {
  backend = "…"
  config = { … }
}

locals {
  remote = {
    kubeconfig = data.terraform_remote_state.cluster_base.outputs.kubeconfig
  }
}

provider "helm" {
  kubernetes {
    host     = local.remote.kubeconfig.host
    client_certificate     = local.remote.kubeconfig.client_certificate
    client_key             = local.remote.kubeconfig.client_key
    cluster_ca_certificate = local.remote.kubeconfig.cluster_ca_certificate
  }
}
```

🥳 