### PR TITLE
Feature/agent group options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See a more detailed example with walk-through in the [example folder](./example)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agent_groups"></a> [agent\_groups](#input\_agent\_groups) | Configuration of agent groups | <pre>map(object({<br>    type      = string<br>    count     = number<br>    ip_offset = number<br>  }))</pre> | <pre>{<br>  "default": {<br>    "count": 2,<br>    "ip_offset": 33,<br>    "type": "cx21"<br>  }<br>}</pre> | no |
+| <a name="input_agent_groups"></a> [agent\_groups](#input\_agent\_groups) | Configuration of agent groups | <pre>map(object({<br>    type      = string<br>    count     = number<br>    ip_offset = number<br>    taints    = list(string)<br>  }))</pre> | <pre>{<br>  "default": {<br>    "count": 2,<br>    "ip_offset": 33,<br>    "taints": [],<br>    "type": "cx21"<br>  }<br>}</pre> | no |
 | <a name="input_cluster_cidr"></a> [cluster\_cidr](#input\_cluster\_cidr) | Network CIDR to use for pod IPs | `string` | `"10.42.0.0/16"` | no |
 | <a name="input_control_plane_server_count"></a> [control\_plane\_server\_count](#input\_control\_plane\_server\_count) | Number of control plane nodes | `number` | `3` | no |
 | <a name="input_control_plane_server_type"></a> [control\_plane\_server\_type](#input\_control\_plane\_server\_type) | Server type of control plane servers | `string` | `"cx11"` | no |

--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ See a more detailed example with walk-through in the [example folder](./example)
 | Name | Description |
 |------|-------------|
 | <a name="output_agents_public_ips"></a> [agents\_public\_ips](#output\_agents\_public\_ips) | The public IP addresses of the agent servers |
+| <a name="output_cidr_block"></a> [cidr\_block](#output\_cidr\_block) | n/a |
 | <a name="output_control_planes_public_ips"></a> [control\_planes\_public\_ips](#output\_control\_planes\_public\_ips) | The public IP addresses of the control plane servers |
 | <a name="output_k3s_token"></a> [k3s\_token](#output\_k3s\_token) | Secret k3s authentication token |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Structured kubeconfig data to supply to other providers |
 | <a name="output_kubeconfig_file"></a> [kubeconfig\_file](#output\_kubeconfig\_file) | Kubeconfig file content with external IP address |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | n/a |
 | <a name="output_ssh_private_key"></a> [ssh\_private\_key](#output\_ssh\_private\_key) | Key to SSH into nodes |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Common Operations

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ See a more detailed example with walk-through in the [example folder](./example)
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Structured kubeconfig data to supply to other providers |
 | <a name="output_kubeconfig_file"></a> [kubeconfig\_file](#output\_kubeconfig\_file) | Kubeconfig file content with external IP address |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | n/a |
+| <a name="output_server_locations"></a> [server\_locations](#output\_server\_locations) | Array of hetzner server locations we deploy to |
 | <a name="output_ssh_private_key"></a> [ssh\_private\_key](#output\_ssh\_private\_key) | Key to SSH into nodes |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See a more detailed example with walk-through in the [example folder](./example)
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_agent_groups"></a> [agent\_groups](#input\_agent\_groups) | Configuration of agent groups | <pre>map(object({<br>    type      = string<br>    count     = number<br>    ip_offset = number<br>  }))</pre> | <pre>{<br>  "default": {<br>    "count": 2,<br>    "ip_offset": 33,<br>    "type": "cx21"<br>  }<br>}</pre> | no |
+| <a name="input_cluster_cidr"></a> [cluster\_cidr](#input\_cluster\_cidr) | Network CIDR to use for pod IPs | `string` | `"10.42.0.0/16"` | no |
 | <a name="input_control_plane_server_count"></a> [control\_plane\_server\_count](#input\_control\_plane\_server\_count) | Number of control plane nodes | `number` | `3` | no |
 | <a name="input_control_plane_server_type"></a> [control\_plane\_server\_type](#input\_control\_plane\_server\_type) | Server type of control plane servers | `string` | `"cx11"` | no |
 | <a name="input_create_kubeconfig"></a> [create\_kubeconfig](#input\_create\_kubeconfig) | Create a local kubeconfig file to connect to the cluster | `bool` | `true` | no |
@@ -45,9 +46,11 @@ See a more detailed example with walk-through in the [example folder](./example)
 | <a name="input_k3s_version"></a> [k3s\_version](#input\_k3s\_version) | K3s version | `string` | `"v1.21.3+k3s1"` | no |
 | <a name="input_kubeconfig_filename"></a> [kubeconfig\_filename](#input\_kubeconfig\_filename) | Specify the filename of the created kubeconfig file (defaults to kubeconfig-${var.name}.yaml | `any` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Cluster name (used in various places, don't use special chars) | `any` | n/a | yes |
-| <a name="input_network_cidr"></a> [network\_cidr](#input\_network\_cidr) | Network in which the cluster will be placed | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_network_cidr"></a> [network\_cidr](#input\_network\_cidr) | Network in which the cluster will be placed. Ignored if network\_id is defined | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | If specified, no new network will be created. Make sure cluster\_cidr and service\_cidr don't collide with anything in the existing network. | `any` | `null` | no |
 | <a name="input_server_additional_packages"></a> [server\_additional\_packages](#input\_server\_additional\_packages) | Additional packages which will be installed on node creation | `list(string)` | `[]` | no |
 | <a name="input_server_locations"></a> [server\_locations](#input\_server\_locations) | Server locations in which servers will be distributed | `list(string)` | <pre>[<br>  "nbg1",<br>  "fsn1",<br>  "hel1"<br>]</pre> | no |
+| <a name="input_service_cidr"></a> [service\_cidr](#input\_service\_cidr) | Network CIDR to use for services IPs | `string` | `"10.43.0.0/16"` | no |
 | <a name="input_ssh_private_key_location"></a> [ssh\_private\_key\_location](#input\_ssh\_private\_key\_location) | Use this private SSH key instead of generating a new one (Attention: Encrypted keys are not supported) | `string` | `null` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | Subnet in which all nodes are placed | `string` | `"10.0.1.0/24"` | no |
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See a more detailed example with walk-through in the [example folder](./example)
 | <a name="input_control_plane_server_count"></a> [control\_plane\_server\_count](#input\_control\_plane\_server\_count) | Number of control plane nodes | `number` | `3` | no |
 | <a name="input_control_plane_server_type"></a> [control\_plane\_server\_type](#input\_control\_plane\_server\_type) | Server type of control plane servers | `string` | `"cx11"` | no |
 | <a name="input_create_kubeconfig"></a> [create\_kubeconfig](#input\_create\_kubeconfig) | Create a local kubeconfig file to connect to the cluster | `bool` | `true` | no |
-| <a name="input_hcloud_csi_driver_version"></a> [hcloud\_csi\_driver\_version](#input\_hcloud\_csi\_driver\_version) | n/a | `string` | `"v1.5.3"` | no |
+| <a name="input_hcloud_csi_driver_version"></a> [hcloud\_csi\_driver\_version](#input\_hcloud\_csi\_driver\_version) | n/a | `string` | `"v1.6.0"` | no |
 | <a name="input_hcloud_token"></a> [hcloud\_token](#input\_hcloud\_token) | Token to authenticate against Hetzner Cloud | `any` | n/a | yes |
 | <a name="input_k3s_version"></a> [k3s\_version](#input\_k3s\_version) | K3s version | `string` | `"v1.21.3+k3s1"` | no |
 | <a name="input_kubeconfig_filename"></a> [kubeconfig\_filename](#input\_kubeconfig\_filename) | Specify the filename of the created kubeconfig file (defaults to kubeconfig-${var.name}.yaml | `any` | `null` | no |

--- a/addons.tf
+++ b/addons.tf
@@ -1,5 +1,8 @@
 data "template_file" "ccm_manifest" {
   template = file("${path.module}/manifests/hcloud-ccm-net.yaml")
+  vars = {
+    cluster_cidr = var.cluster_cidr
+  }
 }
 
 data "http" "hcloud_csi_driver_manifest" {

--- a/agents.tf
+++ b/agents.tf
@@ -15,7 +15,7 @@ module "agent_group" {
   ssh_private_key         = local.ssh_private_key
 
   control_plane_ip = local.first_control_plane_ip
-  network_id       = hcloud_network.k3s.id
+  network_id       = local.network_id
 
   subnet_id       = hcloud_network_subnet.k3s_nodes.id
   subnet_ip_range = hcloud_network_subnet.k3s_nodes.ip_range

--- a/agents.tf
+++ b/agents.tf
@@ -22,8 +22,9 @@ module "agent_group" {
 
   ip_offset = each.value.ip_offset
 
-  server_count = each.value.count
-  server_type  = each.value.type
+  server_count  = each.value.count
+  server_type   = each.value.type
+  common_labels = local.common_labels
 
   additional_packages = concat(local.server_base_packages, var.server_additional_packages)
 

--- a/agents.tf
+++ b/agents.tf
@@ -6,6 +6,8 @@ module "agent_group" {
   k3s_cluster_secret = random_password.k3s_cluster_secret.result
   k3s_version        = var.k3s_version
 
+  taints = each.value.taints
+
   cluster_name = var.name
   group_name   = each.key
 
@@ -14,8 +16,9 @@ module "agent_group" {
   provisioning_ssh_key_id = hcloud_ssh_key.provision_public.id
   ssh_private_key         = local.ssh_private_key
 
-  control_plane_ip = local.first_control_plane_ip
-  network_id       = local.network_id
+  control_plane_ip        = local.first_control_plane_ip
+  network_id              = local.network_id
+  public_control_plane_ip = hcloud_server.first_control_plane.ipv4_address
 
   subnet_id       = hcloud_network_subnet.k3s_nodes.id
   subnet_ip_range = hcloud_network_subnet.k3s_nodes.ip_range

--- a/agents.tf
+++ b/agents.tf
@@ -25,7 +25,7 @@ module "agent_group" {
   server_count = each.value.count
   server_type  = each.value.type
 
-  additional_packages = var.server_additional_packages
+  additional_packages = concat(local.server_base_packages, var.server_additional_packages)
 
   depends_on = [hcloud_server.first_control_plane]
 }

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -22,7 +22,7 @@ resource "hcloud_server" "control_plane" {
   ))
 
   network {
-    network_id = hcloud_network.k3s.id
+    network_id = local.network_id
     ip         = cidrhost(hcloud_network_subnet.k3s_nodes.ip_range, each.value + 1)
   }
 

--- a/control_plane.tf
+++ b/control_plane.tf
@@ -15,9 +15,9 @@ resource "hcloud_server" "control_plane" {
   user_data = format("%s\n%s", "#cloud-config", yamlencode(
     {
       runcmd = [
-        "curl -sfL https://get.k3s.io | K3S_TOKEN='${random_password.k3s_cluster_secret.result}' INSTALL_K3S_VERSION='${var.k3s_version}' sh -s - server --server 'https://${local.first_control_plane_ip}:6443' --disable local-storage --disable-cloud-controller --disable traefik --disable servicelb --kubelet-arg='cloud-provider=external'"
+        "curl -sfL https://get.k3s.io | K3S_TOKEN='${random_password.k3s_cluster_secret.result}' INSTALL_K3S_VERSION='${var.k3s_version}' sh -s - server --server 'https://${local.first_control_plane_ip}:6443' ${local.k3s_setup_args}"
       ]
-      packages = var.server_additional_packages
+      packages = concat(local.server_base_packages, var.server_additional_packages)
     }
   ))
 

--- a/control_plane_master.tf
+++ b/control_plane_master.tf
@@ -27,7 +27,7 @@ resource "hcloud_server" "first_control_plane" {
       "kubectl taint node ${self.name} node-role.kubernetes.io/master=true:NoSchedule",
       "kubectl taint node ${self.name} CriticalAddonsOnly=true:NoExecute",
       # Install hetzner CCM
-      "kubectl -n kube-system create secret generic hcloud --from-literal=token=${var.hcloud_token} --from-literal=network=${hcloud_network.k3s.name}",
+      "kubectl -n kube-system create secret generic hcloud --from-literal=token=${var.hcloud_token} --from-literal=network=${local.network_name}",
       "kubectl apply -f -<<EOF\n${data.template_file.ccm_manifest.rendered}\nEOF",
       # Install hetzner CSI plugin
       "kubectl -n kube-system create secret generic hcloud-csi --from-literal=token=${var.hcloud_token}",

--- a/control_plane_master.tf
+++ b/control_plane_master.tf
@@ -13,9 +13,9 @@ resource "hcloud_server" "first_control_plane" {
   user_data = format("%s\n%s", "#cloud-config", yamlencode(
     {
       runcmd = [
-        "curl -sfL https://get.k3s.io | K3S_TOKEN='${random_password.k3s_cluster_secret.result}' INSTALL_K3S_VERSION='${var.k3s_version}' sh -s - server --cluster-init --disable local-storage --disable-cloud-controller --disable traefik --disable servicelb --kubelet-arg='cloud-provider=external'"
+        "curl -sfL https://get.k3s.io | K3S_TOKEN='${random_password.k3s_cluster_secret.result}' INSTALL_K3S_VERSION='${var.k3s_version}' sh -s - server --cluster-init ${local.k3s_setup_args}"
       ]
-      packages = var.server_additional_packages
+      packages = concat(local.server_base_packages, var.server_additional_packages)
     }
   ))
 

--- a/main.tf
+++ b/main.tf
@@ -15,5 +15,6 @@ data "hcloud_image" "ubuntu" {
 
 locals {
   server_base_packages = ["wireguard"]
-  k3s_setup_args       = "--disable local-storage --disable-cloud-controller --disable traefik --disable servicelb --flannel-backend=wireguard --kubelet-arg='cloud-provider=external'"
+  cluster_dns_ip       = cidrhost(var.service_cidr, 10)
+  k3s_setup_args       = "--cluster-cidr ${var.cluster_cidr} --service-cidr ${var.service_cidr} --cluster-dns ${local.cluster_dns_ip} --disable local-storage --disable-cloud-controller --disable traefik --disable servicelb --flannel-backend=wireguard --kubelet-arg='cloud-provider=external'"
 }

--- a/main.tf
+++ b/main.tf
@@ -12,3 +12,8 @@ resource "hcloud_ssh_key" "provision_public" {
 data "hcloud_image" "ubuntu" {
   name = "ubuntu-20.04"
 }
+
+locals {
+  server_base_packages = ["wireguard"]
+  k3s_setup_args       = "--disable local-storage --disable-cloud-controller --disable traefik --disable servicelb --flannel-backend=wireguard --kubelet-arg='cloud-provider=external'"
+}

--- a/manifests/hcloud-ccm-net.yaml
+++ b/manifests/hcloud-ccm-net.yaml
@@ -57,7 +57,7 @@ spec:
           effect: "NoSchedule"
       hostNetwork: true
       containers:
-        - image: hetznercloud/hcloud-cloud-controller-manager:v1.11.1
+        - image: hetznercloud/hcloud-cloud-controller-manager:v1.12.0
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"

--- a/manifests/hcloud-ccm-net.yaml
+++ b/manifests/hcloud-ccm-net.yaml
@@ -65,7 +65,7 @@ spec:
             - "--leader-elect=false"
             - "--allow-untagged-cloud"
             - "--allocate-node-cidrs=true"
-            - "--cluster-cidr=10.42.0.0/16"
+            - "--cluster-cidr=${cluster_cidr}"
           resources:
             requests:
               cpu: 100m

--- a/modules/agent_group/agent.tf
+++ b/modules/agent_group/agent.tf
@@ -9,6 +9,7 @@ resource "hcloud_server" "agent" {
   ssh_keys = [var.provisioning_ssh_key_id]
   labels = merge({
     node_type = "worker"
+    cluster   = var.cluster_name
   }, var.common_labels)
 
   # Join cluster as agent after first boot

--- a/modules/agent_group/agent.tf
+++ b/modules/agent_group/agent.tf
@@ -54,11 +54,12 @@ resource "null_resource" "apply_taints" {
 
   triggers = {
     agent_ids = join(",", [for _, agent in hcloud_server.agent : agent.id]),
+    taints    = join(",", var.taints)
   }
 
   provisioner "remote-exec" {
     inline = [
-      for taint in var.taints : "kubectl taint nodes -l agent-group=${var.group_name} ${taint}"
+      for taint in var.taints : "kubectl taint nodes --overwrite -l agent-group=${var.group_name} ${taint}"
     ]
   }
 

--- a/modules/agent_group/agent.tf
+++ b/modules/agent_group/agent.tf
@@ -17,7 +17,7 @@ resource "hcloud_server" "agent" {
   user_data = format("%s\n#%s\n%s", "#cloud-config", local.agent_pet_names[each.value], yamlencode(
     {
       runcmd = [
-        "curl -sfL https://get.k3s.io | K3S_URL='https://${var.control_plane_ip}:6443' INSTALL_K3S_VERSION='${var.k3s_version}' K3S_TOKEN='${var.k3s_cluster_secret}' sh -s - agent --kubelet-arg='cloud-provider=external'"
+        "curl -sfL https://get.k3s.io | K3S_URL='https://${var.control_plane_ip}:6443' INSTALL_K3S_VERSION='${var.k3s_version}' K3S_TOKEN='${var.k3s_cluster_secret}' sh -s - agent --kubelet-arg='cloud-provider=external' --kubelet-arg='node-labels=agent-group=${var.group_name}'"
       ]
       packages = var.additional_packages
     }
@@ -47,4 +47,25 @@ resource "hcloud_server_network" "agent" {
   subnet_id = var.subnet_id
   server_id = hcloud_server.agent[each.key].id
   ip        = cidrhost(var.subnet_ip_range, var.ip_offset + each.value) // start at x.y.z.OFFSET
+}
+
+resource "null_resource" "apply_taints" {
+  count = length(var.taints) > 0 ? 1 : 0
+
+  triggers = {
+    agent_ids = join(",", [for _, agent in hcloud_server.agent : agent.id]),
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      for taint in var.taints : "kubectl taint nodes -l agent-group=${var.group_name} ${taint}"
+    ]
+  }
+
+  connection {
+    host        = var.public_control_plane_ip
+    type        = "ssh"
+    user        = "root"
+    private_key = var.ssh_private_key
+  }
 }

--- a/modules/agent_group/variables.tf
+++ b/modules/agent_group/variables.tf
@@ -32,16 +32,21 @@ variable "control_plane_ip" {
   description = "Control plane IP to connect to"
 }
 
+variable "public_control_plane_ip" {
+  description = "Public control plane IP"
+}
+
+variable "taints" {
+  description = "Taints each worker gets"
+}
 
 variable "k3s_version" {
   description = "K3S version, should match the control plane"
 }
 
-
 variable "k3s_cluster_secret" {
   description = "K3S cluster token to authenticate against control plane"
 }
-
 
 variable "network_id" {
   description = "Network ID to place agents in"

--- a/modules/agent_group/variables.tf
+++ b/modules/agent_group/variables.tf
@@ -38,6 +38,7 @@ variable "public_control_plane_ip" {
 
 variable "taints" {
   description = "Taints each worker gets"
+  type        = list(string)
 }
 
 variable "k3s_version" {

--- a/network.tf
+++ b/network.tf
@@ -1,16 +1,24 @@
 resource "hcloud_network" "k3s" {
+  count    = var.network_id == null ? 1 : 0
   name     = "${var.name}-k3s-network"
   ip_range = var.network_cidr
   labels   = local.common_labels
 }
 
-resource "hcloud_network_subnet" "k3s_nodes" {
-  type         = "cloud"
-  network_id   = hcloud_network.k3s.id
-  network_zone = "eu-central"
-  ip_range     = var.subnet_cidr
+data "hcloud_network" "k3s" {
+  count = var.network_id == null ? 0 : 1
+  id    = var.network_id
 }
 
 locals {
   first_control_plane_ip = cidrhost(hcloud_network_subnet.k3s_nodes.ip_range, 1)
+  network_id             = var.network_id == null ? hcloud_network.k3s[0].id : var.network_id
+  network_name           = var.network_id == null ? hcloud_network.k3s[0].name : data.hcloud_network.k3s[0].name
+}
+
+resource "hcloud_network_subnet" "k3s_nodes" {
+  type         = "cloud"
+  network_id   = local.network_id
+  network_zone = "eu-central"
+  ip_range     = var.subnet_cidr
 }

--- a/output.tf
+++ b/output.tf
@@ -23,3 +23,11 @@ output "k3s_token" {
 output "network_id" {
   value = local.network_id
 }
+
+output "subnet_id" {
+  value = hcloud_network_subnet.k3s_nodes.id
+}
+
+output "cidr_block" {
+  value = hcloud_network_subnet.k3s_nodes.ip_range
+}

--- a/output.tf
+++ b/output.tf
@@ -31,3 +31,9 @@ output "subnet_id" {
 output "cidr_block" {
   value = hcloud_network_subnet.k3s_nodes.ip_range
 }
+
+output "server_locations" {
+  description = "Array of hetzner server locations we deploy to"
+  value       = var.server_locations
+}
+

--- a/output.tf
+++ b/output.tf
@@ -21,5 +21,5 @@ output "k3s_token" {
 }
 
 output "network_id" {
-  value = hcloud_network.k3s.id
+  value = local.network_id
 }

--- a/output.tf
+++ b/output.tf
@@ -36,4 +36,3 @@ output "server_locations" {
   description = "Array of hetzner server locations we deploy to"
   value       = var.server_locations
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -72,12 +72,14 @@ variable "agent_groups" {
       type      = "cx21"
       count     = 2
       ip_offset = 33
+      taints    = []
     }
   }
   type = map(object({
     type      = string
     count     = number
     ip_offset = number
+    taints    = list(string)
   }))
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,8 +23,23 @@ variable "kubeconfig_filename" {
 ## Network
 
 variable "network_cidr" {
-  description = "Network in which the cluster will be placed"
+  description = "Network in which the cluster will be placed. Ignored if network_id is defined"
   default     = "10.0.0.0/16"
+}
+
+variable "cluster_cidr" {
+  description = "Network CIDR to use for pod IPs"
+  default     = "10.42.0.0/16"
+}
+
+variable "service_cidr" {
+  description = "Network CIDR to use for services IPs"
+  default     = "10.43.0.0/16"
+}
+
+variable "network_id" {
+  description = "If specified, no new network will be created. Make sure cluster_cidr and service_cidr don't collide with anything in the existing network."
+  default     = null
 }
 
 variable "subnet_cidr" {

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "k3s_version" {
 }
 
 variable "hcloud_csi_driver_version" {
-  default = "v1.5.3"
+  default = "v1.6.0"
 }
 
 # Labels


### PR DESCRIPTION
This replaces PR https://github.com/StarpTech/k-andy/pull/12 

Notable changes:

- wireguard as flannel backend so cross-az traffic is protected. See https://docs.hetzner.com/cloud/networks/faq/#is-traffic-inside-hetzner-cloud-networks-encrypted
- Allow usage of existing hcloud networks
- Nodes get agent-group name as label so nodeSelectors can be used easily
- Added multiple useful outputs
- It's possible to add taints to node-groups
- Minor version update of hcloud ccm and hcloud csi

